### PR TITLE
Update README.md with Audio Pro devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This component allows you to integrate control of audio devices based on LinkPla
 
 LinkPlay platform makes it easy to create a variety of modern audio systems. There are already quite a few manufacturers and devices that operate on the basis of LinkPlay. Here are just some of the firms and devices:
 **August** (WS300G),
+**Audio Pro** (A10, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1)
 **Auna** (Intelligence Tube),
 **Bauhn** (SoundMax 5),
 **Bem** (Speaker Big Mo),

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This component allows you to integrate control of audio devices based on LinkPla
 
 LinkPlay platform makes it easy to create a variety of modern audio systems. There are already quite a few manufacturers and devices that operate on the basis of LinkPlay. Here are just some of the firms and devices:
 **August** (WS300G),
-**Audio Pro** (A10, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1)
+**Audio Pro** (A10, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1),
 **Auna** (Intelligence Tube),
 **Bauhn** (SoundMax 5),
 **Bem** (Speaker Big Mo),


### PR DESCRIPTION
I'm using the Linkplay component with the Audio Pro line of multiroom speakers and it's working fine, so I thought they ought to be added to README.md.