### PR TITLE
Avoid crashing on slow media player responses

### DIFF
--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -722,6 +722,11 @@ class LinkPlayDevice(MediaPlayerDevice):
         if isinstance(player_status, dict):
             self._lpapi.call('GET', 'getStatus')
             device_api_result = self._lpapi.data
+            if device_api_result is None:
+                _LOGGER.warning('Unable to connect to device')
+                self._media_title = 'Unable to connect to device'
+                return True
+
             try:
                 device_status = json.loads(device_api_result)
             except ValueError:

--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -701,7 +701,8 @@ class LinkPlayDevice(MediaPlayerDevice):
                         self._upnp_device = upnpclient.Device(entry.location)
                         break
                 except (requests.exceptions.HTTPError,
-                        requests.exceptions.MissingSchema):
+                        requests.exceptions.MissingSchema,
+                        lxml.etree.XMLSyntaxError):
                     pass
 
         self._lpapi.call('GET', 'getPlayerStatus')


### PR DESCRIPTION
I sometimes get crashes in my HA log similar to what was seen in issue #5 . It seems to be due to HTTP requests or UPnP calls timing out or returning empty responses.

This PR fixes two of these crashes that I have seen in my logs.