### PR TITLE
Remove UPNP error log messages

### DIFF
--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -704,7 +704,7 @@ class LinkPlayDevice(MediaPlayerDevice):
             return True
 
         if self._upnp_device is None:
-            for entry in upnp_discover(UPNP_TIMEOUT):
+            for entry in self.upnp_discover(UPNP_TIMEOUT):
                 if entry.friendly_name == \
                         self._devicename:
                     self._upnp_device = upnpclient.Device(entry.location)

--- a/custom_components/linkplay/media_player.py
+++ b/custom_components/linkplay/media_player.py
@@ -9,6 +9,7 @@ https://home-assistant.io/components/media_player.linkplay/
 import binascii
 import json
 import upnpclient
+import netdisco.ssdp
 import logging
 import os
 import tempfile
@@ -687,7 +688,7 @@ class LinkPlayDevice(MediaPlayerDevice):
 
     def upnp_discover(self, timeout=5):
         devices = {}
-        for entry in upnpclient.scan(timeout):
+        for entry in netdisco.ssdp.scan(timeout):
             if entry.location in devices:
                 continue
             try:


### PR DESCRIPTION
Every time the component did a scan of the network it would fail to scan some UPNP devices, that wasn't a problem since we don't care about device that aren't linkplay devices. But every failure would output a log message in the HA log. This PR will remove the annoying log messages in the HA log.